### PR TITLE
fixes broken path urls in admin interface

### DIFF
--- a/vendor/extensions/articles/app/views/refinery/articles/admin/articles/_article.html.erb
+++ b/vendor/extensions/articles/app/views/refinery/articles/admin/articles/_article.html.erb
@@ -6,7 +6,7 @@
   <span class='preview'></span>
 
   <span class='actions'>
-    <%= action_icon(:preview, refinery.articles_article_path(article), t('.view_live_html')) %>
+    <%= action_icon(:preview, refinery.articles_path, t('.view_live_html')) %>
     <%= action_icon(:edit,    refinery.edit_articles_admin_article_path(article), t('.edit') ) %>
     <%= action_icon(:delete,  refinery.articles_admin_article_path(article), t('.delete'),
       { class: "cancel confirm-delete",

--- a/vendor/extensions/team_members/app/views/refinery/team_members/admin/team_members/_team_member.html.erb
+++ b/vendor/extensions/team_members/app/views/refinery/team_members/admin/team_members/_team_member.html.erb
@@ -6,7 +6,7 @@
   <span class='preview'></span>
 
   <span class='actions'>
-    <%= action_icon(:preview, refinery.team_members_team_member_path(team_member), t('.view_live_html')) %>
+    <%= action_icon(:preview, refinery.team_member_path(team_member), t('.view_live_html')) %>
     <%= action_icon(:edit,    refinery.edit_team_members_admin_team_member_path(team_member), t('.edit') ) %>
     <%= action_icon(:delete,  refinery.team_members_admin_team_member_path(team_member), t('.delete'),
       { class: "cancel confirm-delete",


### PR DESCRIPTION
I just edited the path helpers. It didn't make sense to have a live show page link for articles, so I just pointed each live link to the main articles index page. It did make sense to have a live project page link, so I just used the appropriate path helper from `rake routes`