### PR TITLE
I don't know why deleting the blank line before refinerycms-custom_pa…

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -76,5 +76,4 @@ gem 'refinerycms-team_members', path: 'vendor/extensions'
 gem 'refinerycms-tags', path: 'vendor/extensions'
 gem 'refinerycms-articles', path: 'vendor/extensions'
 gem 'refinerycms-organization_tabs', path: 'vendor/extensions'
-
 gem 'refinerycms-custom_pages', path: 'vendor/extensions'


### PR DESCRIPTION
…ges fixed not being able to acces CustomPages in console but it did